### PR TITLE
Add Optional vault_iam_role_name Variable

### DIFF
--- a/examples/vault-cluster-private/main.tf
+++ b/examples/vault-cluster-private/main.tf
@@ -26,6 +26,8 @@ module "vault_cluster" {
   cluster_size  = "${var.vault_cluster_size}"
   instance_type = "${var.vault_instance_type}"
 
+  iam_role_name = "${var.vault_iam_role_name}"
+
   ami_id    = "${var.ami_id}"
   user_data = "${data.template_file.user_data_vault_cluster.rendered}"
 

--- a/examples/vault-cluster-private/variables.tf
+++ b/examples/vault-cluster-private/variables.tf
@@ -53,6 +53,11 @@ variable "consul_cluster_size" {
   default     = 3
 }
 
+variable "vault_iam_role_name" {
+  description = "The name to use for the Vault server cluster instances' IAM role. Use this setting to ensure a determensitc IAM role ARN, otherwise the default will see terraform create a unique IAM role name (prefixed by the vault_cluster_name variable)."
+  default     = ""
+}
+
 variable "vault_instance_type" {
   description = "The type of EC2 Instance to run in the Vault ASG"
   default     = "t2.micro"

--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,8 @@ module "vault_cluster" {
   cluster_size  = "${var.vault_cluster_size}"
   instance_type = "${var.vault_instance_type}"
 
+  iam_role_name = "${var.vault_iam_role_name}"
+
   ami_id    = "${var.ami_id == "" ? data.aws_ami.vault_consul.image_id : var.ami_id}"
   user_data = "${data.template_file.user_data_vault_cluster.rendered}"
 

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -317,7 +317,7 @@ Check out the [Security section](#security) for more details.
 
 Each EC2 Instance in the ASG has an [IAM Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) attached
 with permissions to access its S3 bucket. The IAM Role ARN is exported as an output variable so you can add custom
-permissions. If you require a deterministic IAM role ARN, the `vault_iam_role_name` variable can be set to your desired
+permissions. If you require a deterministic IAM role ARN, the `iam_role_name` variable can be set to your desired
 role name. 
 
 

--- a/modules/vault-cluster/README.md
+++ b/modules/vault-cluster/README.md
@@ -317,7 +317,8 @@ Check out the [Security section](#security) for more details.
 
 Each EC2 Instance in the ASG has an [IAM Role](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles.html) attached
 with permissions to access its S3 bucket. The IAM Role ARN is exported as an output variable so you can add custom
-permissions. 
+permissions. If you require a deterministic IAM role ARN, the `vault_iam_role_name` variable can be set to your desired
+role name. 
 
 
 

--- a/modules/vault-cluster/outputs.tf
+++ b/modules/vault-cluster/outputs.tf
@@ -19,11 +19,11 @@ output "launch_config_name" {
 }
 
 output "iam_role_arn" {
-  value = "${aws_iam_role.instance_role.arn}"
+  value = "${data.aws_iam_role.instance_role.arn}"
 }
 
 output "iam_role_id" {
-  value = "${aws_iam_role.instance_role.id}"
+  value = "${data.aws_iam_role.instance_role.id}"
 }
 
 output "security_group_id" {

--- a/modules/vault-cluster/variables.tf
+++ b/modules/vault-cluster/variables.tf
@@ -156,6 +156,11 @@ variable "health_check_grace_period" {
   default     = 300
 }
 
+variable "iam_role_name" {
+  description = "The name to use for the Vault instances' IAM role. Use this setting to ensure a determensitc IAM role ARN, otherwise the default will see terraform create a unique IAM role name (prefixed by the vault_cluster_name variable)."
+  default     = ""
+}
+
 variable "instance_profile_path" {
   description = "Path in which to create the IAM instance profile."
   default     = "/"

--- a/variables.tf
+++ b/variables.tf
@@ -66,6 +66,11 @@ variable "consul_cluster_size" {
   default     = 3
 }
 
+variable "vault_iam_role_name" {
+  description = "The name to use for the Vault cluster instance(s) IAM role. Use this setting to ensure a determensitc IAM role ARN, otherwise the default will see terraform create a unique IAM role name (prefixed by the vault_cluster_name variable)."
+  default     = ""
+}
+
 variable "vault_instance_type" {
   description = "The type of EC2 Instance to run in the Vault ASG"
   default     = "t2.micro"


### PR DESCRIPTION
[DRY RUN OF REAL PR FOR LOCAL TESTING ;P]

Associated Issue: terraform-aws-vault/issues/22

No test updates included here. I considered if adding testing for the case of a user-provided value of the added `vault_iam_role_name` variable. However that feels like testing how terraform itself behaves rather than the responsibility of this codebase.